### PR TITLE
Fix: str_replace() Passing null to parameter #3 ($subject) is deprecated

### DIFF
--- a/src/PaginateRoute.php
+++ b/src/PaginateRoute.php
@@ -74,7 +74,11 @@ class PaginateRoute
 
         $query = $currentRoute->parameter('pageQuery');
 
-        return (int) str_replace($this->pageKeyword, '', $query) ?: 1;
+        if ($query === null) {
+            return 1;
+        }
+
+        return (int) str_replace($this->pageKeyword, '', $query);
     }
 
     /**


### PR DESCRIPTION
Fix PHP 8.3 warning